### PR TITLE
Use Streams for SFTP Subsystem

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::io::ErrorKind;
+
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq, Eq)]
@@ -8,8 +10,14 @@ pub enum Error {
     #[error("Configuration error: {}", .0)]
     Configuration(String),
 
+    #[error("End of file.")]
+    EndOfFile,
+
     #[error("{}", .0)]
     Failure(String),
+
+    #[error("IO Error: {}", .0)]
+    IOError(std::io::ErrorKind),
 
     #[error("File not found.")]
     NoSuchFile,
@@ -32,7 +40,10 @@ impl From<envy::Error> for Error {
 
 impl From<std::io::Error> for Error {
     fn from(io_error: std::io::Error) -> Self {
-        Error::Storage(io_error.to_string())
+        match io_error.kind() {
+            ErrorKind::UnexpectedEof => Error::EndOfFile,
+            _ => Error::IOError(io_error.kind()),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod error;
 mod protocol;
 mod sftp_session;
+mod sftp_stream;
 mod ssh_keys;
 pub mod ssh_server;
 pub mod storage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
     dotenv().ok();
 
     env_logger::Builder::new()
-        .filter_level(LevelFilter::Info)
+        .filter_level(LevelFilter::Debug)
         .init();
 
     info!("Starting Dray");

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
     dotenv().ok();
 
     env_logger::Builder::new()
-        .filter_level(LevelFilter::Debug)
+        .filter_level(LevelFilter::Info)
         .init();
 
     info!("Starting Dray");

--- a/src/sftp_session.rs
+++ b/src/sftp_session.rs
@@ -7,13 +7,12 @@ use crate::{
         response::{self, Response},
     },
 };
-use bytes::{BufMut, Bytes, BytesMut};
+
 use log::error;
 use log::info;
-use russh::ChannelStream;
-use std::convert::TryFrom;
+
 use std::sync::Arc;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncReadExt;
 
 pub struct SftpSession {
     object_storage: Arc<dyn Storage>,

--- a/src/sftp_session.rs
+++ b/src/sftp_session.rs
@@ -12,7 +12,6 @@ use log::error;
 use log::info;
 
 use std::sync::Arc;
-use tokio::io::AsyncReadExt;
 
 pub struct SftpSession {
     object_storage: Arc<dyn Storage>,

--- a/src/sftp_session.rs
+++ b/src/sftp_session.rs
@@ -32,28 +32,6 @@ impl SftpSession {
         }
     }
 
-    pub async fn process_stream(&self, mut stream: ChannelStream) {
-        loop {
-            // TODO: Modify the protocol to act on the stream instead of the Byte object
-
-            let message_size = stream.read_u32().await.unwrap();
-            let mut buf = BytesMut::with_capacity(message_size as usize + 4);
-
-            // Hack: Existing parser expects the message size
-            buf.put_u32(message_size);
-
-            stream.read_buf(&mut buf).await.unwrap();
-
-            let mut buf = buf.freeze();
-
-            let request = Request::try_from(&mut buf).unwrap();
-            let response = self.handle_request(request).await;
-            let response_bytes = Bytes::from(&response).to_vec();
-
-            stream.write_all(&response_bytes).await.unwrap();
-        }
-    }
-
     pub async fn handle_request(&self, request: Request) -> Response {
         info!("Received request: {:?}", request);
 

--- a/src/sftp_stream.rs
+++ b/src/sftp_stream.rs
@@ -54,6 +54,7 @@ impl SftpStream {
 }
 
 fn parse_request_frame(buffer: &mut BytesMut) -> Option<Bytes> {
+    // TODO: Add unit tests
     let length_field_size = mem::size_of::<u32>();
 
     let mut peeker = Cursor::new(&buffer[..]);

--- a/src/sftp_stream.rs
+++ b/src/sftp_stream.rs
@@ -1,10 +1,14 @@
-use std::{convert::TryFrom, io::{ErrorKind, Cursor}, mem};
+use std::{
+    convert::TryFrom,
+    io::{Cursor, ErrorKind},
+    mem,
+};
 
-use bytes::{Bytes, BytesMut, Buf};
+use bytes::{Bytes, BytesMut};
 use russh::ChannelStream;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use crate::{error::Error, protocol::{request::Request, response::data}, sftp_session::SftpSession, try_buf::TryBuf};
+use crate::{error::Error, protocol::request::Request, sftp_session::SftpSession, try_buf::TryBuf};
 
 pub struct SftpStream {
     sftp_session: SftpSession,
@@ -58,7 +62,7 @@ fn parse_request_frame(buffer: &mut BytesMut) -> Option<Bytes> {
         Ok(data_length) => data_length,
         Err(_) => return None,
     };
-    
+
     let frame_length = data_length + length_field_size as u32;
 
     match buffer.try_get_bytes(frame_length) {

--- a/src/sftp_stream.rs
+++ b/src/sftp_stream.rs
@@ -1,0 +1,68 @@
+use std::{convert::TryFrom, io::{ErrorKind, Cursor}, mem};
+
+use bytes::{Bytes, BytesMut, Buf};
+use russh::ChannelStream;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::{error::Error, protocol::{request::Request, response::data}, sftp_session::SftpSession, try_buf::TryBuf};
+
+pub struct SftpStream {
+    sftp_session: SftpSession,
+}
+
+impl SftpStream {
+    pub fn new(sftp_session: SftpSession) -> SftpStream {
+        SftpStream { sftp_session }
+    }
+
+    pub async fn process_stream(&self, mut stream: ChannelStream) -> Result<(), Error> {
+        let mut buffer = BytesMut::with_capacity(4096);
+
+        loop {
+            if let Some(mut frame) = parse_request_frame(&mut buffer) {
+                let response = match Request::try_from(&mut frame) {
+                    Ok(request) => self.sftp_session.handle_request(request).await,
+                    Err(_) => SftpSession::build_invalid_request_message_response(),
+                };
+
+                let response_bytes = Bytes::from(&response);
+
+                match stream.write_all(&response_bytes).await {
+                    Ok(_) => {}
+                    Err(error) => return Err(Error::Failure(error.to_string())),
+                }
+            }
+
+            let bytes_read = match stream.read_buf(&mut buffer).await {
+                Ok(bytes_read) => bytes_read,
+                Err(error) => return Err(Error::Failure(error.to_string())),
+            };
+
+            if 0 == bytes_read {
+                if buffer.is_empty() {
+                    return Ok(());
+                } else {
+                    return Err(Error::Failure(ErrorKind::ConnectionReset.to_string()));
+                }
+            }
+        }
+    }
+}
+
+fn parse_request_frame(buffer: &mut BytesMut) -> Option<Bytes> {
+    let length_field_size = mem::size_of::<u32>();
+
+    let mut peeker = Cursor::new(&buffer[..]);
+
+    let data_length = match peeker.try_get_u32() {
+        Ok(data_length) => data_length,
+        Err(_) => return None,
+    };
+    
+    let frame_length = data_length + length_field_size as u32;
+
+    match buffer.try_get_bytes(frame_length) {
+        Ok(frame) => Some(frame),
+        Err(_) => None,
+    }
+}

--- a/src/ssh_server.rs
+++ b/src/ssh_server.rs
@@ -1,5 +1,5 @@
 use crate::config::DrayConfig;
-use crate::error::{Error};
+use crate::error::Error;
 use crate::sftp_session::SftpSession;
 use crate::sftp_stream::SftpStream;
 use crate::storage::{s3::S3StorageFactory, Storage, StorageFactory};
@@ -14,7 +14,7 @@ use russh_keys::{
     PublicKeyBase64,
 };
 use std::collections::HashMap;
-use std::{convert::TryFrom, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 
 pub struct DraySshServer {
@@ -228,7 +228,7 @@ impl Handler for DraySshServer {
 
         Ok((self, session))
     }
-    
+
     async fn channel_eof(
         self,
         channel: ChannelId,

--- a/src/ssh_server.rs
+++ b/src/ssh_server.rs
@@ -222,6 +222,7 @@ impl Handler for DraySshServer {
 
             match sftp_stream.process_stream(stream).await {
                 Ok(_) => debug!("Sftp subsystem session finished"),
+                // TODO: Do not mark EOF as failure - refactor stream code
                 Err(error) => error!("Sftp subsystem failed: {}", error),
             };
         });

--- a/src/ssh_server.rs
+++ b/src/ssh_server.rs
@@ -217,12 +217,12 @@ impl Handler for DraySshServer {
         let sftp_stream = SftpStream::new(sftp_session);
 
         tokio::spawn(async move {
-            debug!("Sftp subsystem starting");
+            info!("Sftp subsystem starting");
 
             let stream = channel.into_stream();
 
             match sftp_stream.process_stream(stream).await {
-                Ok(_) => debug!("Sftp subsystem session finished"),
+                Ok(_) => info!("Sftp subsystem finished"),
                 Err(error) => error!("Sftp subsystem failed: {}", error),
             };
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -21,12 +21,13 @@ use rusoto_s3::{
 };
 use tempfile::NamedTempFile;
 use tokio::{
+    fs,
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpStream,
     process::Command,
     spawn,
     task::spawn_blocking,
-    time::{sleep, Duration}, fs,
+    time::{sleep, Duration},
 };
 
 #[tokio::test]
@@ -74,7 +75,7 @@ async fn test_read_file() {
     .await;
 
     let temp_file = NamedTempFile::new().unwrap().into_temp_path();
-    
+
     execute_sftp_command(
         &test_client,
         &format!(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -26,7 +26,7 @@ use tokio::{
     process::Command,
     spawn,
     task::spawn_blocking,
-    time::{sleep, Duration},
+    time::{sleep, Duration}, fs,
 };
 
 #[tokio::test]
@@ -73,20 +73,19 @@ async fn test_read_file() {
     )
     .await;
 
-    let mut temp_file = NamedTempFile::new().unwrap();
-
+    let temp_file = NamedTempFile::new().unwrap().into_temp_path();
+    
     execute_sftp_command(
         &test_client,
         &format!(
             "GET /home/test/read-test.txt {}",
-            temp_file.path().to_string_lossy()
+            temp_file.to_string_lossy()
         ),
     )
     .await
     .unwrap();
 
-    let mut file_data = String::new();
-    temp_file.read_to_string(&mut file_data).unwrap();
+    let file_data = fs::read_to_string(temp_file).await.unwrap();
 
     assert_eq!("Test read data!", &file_data);
 }
@@ -105,15 +104,15 @@ async fn test_read_file_with_permission_error() {
 async fn test_write_file() {
     let test_client = setup().await;
 
-    let mut temp_file = NamedTempFile::new().unwrap();
-    temp_file.write_all(b"Test write data!").unwrap();
-    temp_file.flush().unwrap();
+    let temp_file = NamedTempFile::new().unwrap().into_temp_path();
+
+    fs::write(&temp_file, b"Test write data!").await.unwrap();
 
     execute_sftp_command(
         &test_client,
         &format!(
             "PUT {} /home/test/write-test.txt",
-            temp_file.path().to_string_lossy()
+            temp_file.to_string_lossy()
         ),
     )
     .await
@@ -129,13 +128,13 @@ async fn test_write_file() {
 async fn test_write_file_with_permission_error() {
     let test_client = setup().await;
 
-    let temp_file = NamedTempFile::new().unwrap();
+    let temp_file = NamedTempFile::new().unwrap().into_temp_path();
 
     execute_sftp_command(
         &test_client,
         &format!(
             "PUT {} /home/other/write-test.txt",
-            temp_file.path().to_string_lossy()
+            temp_file.to_string_lossy()
         ),
     )
     .await

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,5 @@
 use std::{
     env,
-    io::{Read, Write},
     net::TcpListener,
     process::Stdio,
     str::FromStr,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,9 +1,4 @@
-use std::{
-    env,
-    net::TcpListener,
-    process::Stdio,
-    str::FromStr,
-};
+use std::{env, net::TcpListener, process::Stdio, str::FromStr};
 
 use dray::{
     config::{DrayConfig, S3Config},


### PR DESCRIPTION
Use streams for SFTP subsystem instead of using the data callbacks. This will allow framing requests that are split across packets, which will address #21 (Windows OpenSSH Bug).